### PR TITLE
Add observeDeep functions to y-array

### DIFF
--- a/src/Array.js
+++ b/src/Array.js
@@ -280,8 +280,14 @@ function extend (Y) {
     observe (f) {
       this.eventHandler.addEventListener(f)
     }
+    observeDeep (f) {
+      this._deepEventHandler.addEventListener(f)
+    }
     unobserve (f) {
       this.eventHandler.removeEventListener(f)
+    }
+    unobserveDeep (f) {
+      this._deepEventHandler.addEventListener(f)
     }
     * _changed (transaction, op) {
       if (!op.deleted) {


### PR DESCRIPTION
Hello sir,

From my limited understanding, I believe that you meant to add these functions to y-array (you did so for y-map). It seems like you already had the rest of the stuff there, like the _deepEventHandler object.

However, I haven't had much luck actually receiving these events, even after adding these functions. We have some differences in our fork of YJS that makes me unclear about where the issue is.

Perhaps some changes on your local computer were missed? I don't have the gulp setup integrated into our fork of YJS either, so I didn't run your tests for y-array yet -- but I don't see how they would work.